### PR TITLE
Remove BOM from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-﻿configparser
+configparser
 groq
 transformers
 torch


### PR DESCRIPTION
Recreated the `requirements.txt` file without BOM character.
Closes #10 