### PR TITLE
Add file upload button to Get File Path

### DIFF
--- a/nodes/get_file_path.py
+++ b/nodes/get_file_path.py
@@ -19,14 +19,14 @@ class GetFilePath:
         files = [f for f in os.listdir(input_dir) if os.path.isfile(os.path.join(input_dir, f))]
         return {
             "required": {
-                "file": (sorted(files), {"file_upload": True, "tooltip": "Place your files in the 'input'-folder inside ComfyUI.\n\nBrowsing functionality is not yet supported. Please send help!"}),
+                "image": (sorted(files), {"image_upload": True, "tooltip": "Make sure to select any file type when uploading a non-image file."}),
             }
         }
 
-    def get_file_path(self, file):
+    def get_file_path(self, image):
         try:
             # Handle file upload within the node logic
-            uploaded_file_path = self.upload_file(file)
+            uploaded_file_path = self.upload_file(image)
 
             # Resolve the full file path using folder_paths
             full_file_path = Path(uploaded_file_path)
@@ -54,21 +54,21 @@ class GetFilePath:
             print(f"Error: Failed to process file path. Details: {str(e)}")
             return None, None, None, None
 
-    def upload_file(self, file):
+    def upload_file(self, image):
         try:
             # Define where to save uploaded files (e.g., input directory)
             input_dir = folder_paths.get_input_directory()
-            file_path = os.path.join(input_dir, file)
+            file_path = os.path.join(input_dir, image)
 
             # Check if file already exists in the directory
             if os.path.exists(file_path):
-                print(f"File {file} already exists in {input_dir}. Skipping upload.")
+                print(f"File {image} already exists in {input_dir}. Skipping upload.")
                 return file_path
 
             # Mimic the upload logic
             with open(file_path, "wb") as f:
                 # Here, you would write the file content to disk
-                f.write(file)  # Assuming `file` contains the file data
+                f.write(image)  # Assuming `file` contains the file data
 
             print(f"File uploaded successfully: {file_path}")
             return file_path


### PR DESCRIPTION
So this was kind of a headscratcher, and I don't entirely understand why it works but I managed to add a browse button to the Get File Path node. tl;dr is that I changed the `file` input name to `image` and the `file_upload` parameter to `image_upload`.

![revised get file path](https://github.com/user-attachments/assets/8cfa32f1-0ec2-4903-915e-cec8018a98aa)

My best guess at what's happening is that `IMAGE` and `AUDIO` are datatypes used internally, and so there's undocumented `image_upload` and `audio_upload` parameters that will expose a file upload button IF the input is named `image` or `audio` respectively. There's no `FILE` datatype so I assume that's why you can't just use a more generic `file` and `file_upload`.

Using that file upload button will open a prompt set to look for files with MIME types of `image/*` or `audio/*` depending on which you used, but validation of the filetype is expected to be handled by the node, so you can just select any file type in the prompt and Comfy will happily allow you to upload whatever.

This is all speculation though as I haven't been able to find anything in the documentation or Comfy's source code that definitively confirms anything.